### PR TITLE
fix jq formatting

### DIFF
--- a/.github/actions/packageMinorVersionUpdater/action.yml
+++ b/.github/actions/packageMinorVersionUpdater/action.yml
@@ -8,7 +8,7 @@ runs:
         newVersion=$(jq -r '.packageDirectories[0].versionNumber' sfdx-project.json |
           awk -F. -v OFS=. '{$2++ ; print}')
         file=$(mktemp)
-        jq -r ".packageDirectories[0].versionNumber = \"$newVersion\"" sfdx-project.json > "$file"
+        jq --indent 4 -r ".packageDirectories[0].versionNumber = \"$newVersion\"" sfdx-project.json > "$file"
         cat "$file" > sfdx-project.json
         rm "$file"
       shell: bash


### PR DESCRIPTION
when workflow changes version number in sfdx-project.json it formats output with 2 spaces as indent, but we are using 4 spaces.
problem came after update of 'jq' tool to v1.6 https://github.com/stedolan/jq/releases/tag/jq-1.6 . as jq noq uses '.' as default filter and  jq by default pretty-prints all output.
