### PR TITLE
PTCRM-367 Oppdatere changelog-generator til nyeste versjon

### DIFF
--- a/.github/workflows/packageCreate.yml
+++ b/.github/workflows/packageCreate.yml
@@ -96,7 +96,7 @@ jobs:
       # Generate changelog from commits
       - name: Generate changelog
         id: changelog
-        uses: metcalfc/changelog-generator@v3.0.0
+        uses: metcalfc/changelog-generator@v4.1.0
         with:
           myToken: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/packageCreateBeta.yml
+++ b/.github/workflows/packageCreateBeta.yml
@@ -92,7 +92,7 @@ jobs:
       # Generate changelog from commits
       - name: Generate changelog
         id: changelog
-        uses: metcalfc/changelog-generator@v3.0.0
+        uses: metcalfc/changelog-generator@v4.1.0
         with:
           myToken: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/packagePromotion.yml
+++ b/.github/workflows/packagePromotion.yml
@@ -140,7 +140,7 @@ jobs:
       # Generate changelog from commits
       - name: Generate changelog
         id: changelog
-        uses: metcalfc/changelog-generator@v0.4.3
+        uses: metcalfc/changelog-generator@v4.1.0
         with:
           myToken: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/quickPackageCreate.yml
+++ b/.github/workflows/quickPackageCreate.yml
@@ -84,7 +84,7 @@ jobs:
       # Generate changelog from commits
       - name: Generate changelog
         id: changelog
-        uses: metcalfc/changelog-generator@v0.4.3
+        uses: metcalfc/changelog-generator@v4.1.0
         with:
           myToken: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Oppdaterer til v4.1.0 for å fikse disse endringene:
- https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
- https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

Releasen ser sånn ut: https://github.com/navikt/crm-platform-base/releases/tag/v0.192.0-beta7
Fra testkjøring: https://github.com/navikt/crm-platform-base/actions/runs/4743139677 (det er fire warnings som ligger her, men de peker en annen action som er oppdatert her: https://github.com/navikt/crm-workflows-base/pull/31)