### PR TITLE
PTCRM-367 Oppdater action som brukes i Create Release

### DIFF
--- a/.github/workflows/packageCreate.yml
+++ b/.github/workflows/packageCreate.yml
@@ -102,12 +102,11 @@ jobs:
 
       # create github release
       - name: Create Release
-        uses: actions/create-release@latest
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v1
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           tag_name: ${{ steps.release-fields.outputs.tagName }}
-          release_name: ${{ steps.release-fields.outputs.releaseName }}
+          name: ${{ steps.release-fields.outputs.releaseName }}
           body: |
             **Version**: ${{ steps.release-fields.outputs.bodyVersion }}
             **Package ID**: ${{ steps.release-fields.outputs.bodyPackage }}

--- a/.github/workflows/packageCreateBeta.yml
+++ b/.github/workflows/packageCreateBeta.yml
@@ -98,16 +98,14 @@ jobs:
 
       # create github release
       - name: Create Release
-        uses: actions/create-release@latest
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v1
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           tag_name: ${{ steps.release-fields.outputs.tagName }}
-          release_name: ${{ steps.release-fields.outputs.releaseName }}
+          name: ${{ steps.release-fields.outputs.releaseName }}
           body: |
             **Version**: ${{ steps.release-fields.outputs.bodyVersion }}
             **Package ID**: ${{ steps.release-fields.outputs.bodyPackage }}
-            **Code Coverage**: ${{ needs.create-package.outputs.codeCoverage }}%
             **Author**: ${{ github.actor }}
             ${{ steps.release-fields.outputs.packageCreation }}
             ${{ steps.release-fields.outputs.integrationInstallation }}


### PR DESCRIPTION
Bytter til ny release action da den vi brukt er arkivert fra GitHub sin side og den støtter ikke de nye endringene til GitHub (vil dermed slutte å fungere)

Link til den nye: https://github.com/softprops/action-gh-release/releases

Releasen ser sånn ut: https://github.com/navikt/crm-platform-base/releases/tag/v0.192.0-beta11
Fra testkjøring: https://github.com/navikt/crm-platform-base/actions/runs/4758082830 (det er to warnings som ligger her, men de peker en annen action som er oppdatert her: https://github.com/navikt/crm-workflows-base/pull/30)
