### PR TITLE
PTCRM-367 - Oppdatere github release

### DIFF
--- a/.github/workflows/packagePromotion.yml
+++ b/.github/workflows/packagePromotion.yml
@@ -146,12 +146,11 @@ jobs:
 
       # create github release
       - name: Create GitHub Release
-        uses: actions/create-release@latest
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v1
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           tag_name: ${{steps.release-fields.outputs.tagName}}
-          release_name: ${{steps.release-fields.outputs.releaseName}}
+          name: ${{steps.release-fields.outputs.releaseName}}
           body: |
             **Version**: ${{ steps.release-fields.outputs.bodyVersion }}
             **Package ID**: ${{ github.event.inputs.packageId }}

--- a/.github/workflows/quickPackageCreate.yml
+++ b/.github/workflows/quickPackageCreate.yml
@@ -90,12 +90,11 @@ jobs:
 
       # create github release
       - name: Create Release
-        uses: actions/create-release@latest
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v1
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           tag_name: ${{ steps.release-fields.outputs.tagName }}
-          release_name: ${{ steps.release-fields.outputs.releaseName }}
+          name: ${{ steps.release-fields.outputs.releaseName }}
           body: |
             **Version**: ${{ steps.release-fields.outputs.bodyVersion }}
             **Package ID**: ${{ steps.release-fields.outputs.bodyPackage }}


### PR DESCRIPTION
Var to workflows til som også måtte bytte ut create-release

Mulig vi må se på å lage en egen release action. Da slipper vi å manuelt oppdatere dette over flere filer