### PR TITLE
Satt SFDX versjonen litt lavere. Ser ut til at vi får en oclif feil ved pakkeinstallering.

### DIFF
--- a/.github/actions/installSFDX/action.yml
+++ b/.github/actions/installSFDX/action.yml
@@ -3,7 +3,7 @@ description: "Install SFDX cli with npm"
 inputs:
   version:
     description: "Version for the SFDX CLI version"
-    default: "7.196.9"
+    default: "7.193.2"
     required: false
 runs:
   using: "composite"


### PR DESCRIPTION
Dette er en midlertidig fiks frem til man får skrevet om alle sfdx kall til å bruke sf.